### PR TITLE
docs: fix typos and capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # tailscale-action
-Hugging Face Github action to connect to tailscale (Based from https://github.com/tailscale/github-action)
+Hugging Face GitHub Action to connect to Tailscale (Based on https://github.com/tailscale/github-action)
 
-You can use this github action for 2 differents use cases :
-- Access to internal shared ressources (like registry)
+You can use this GitHub Action for 2 different use cases:
+- Access to internal shared resources (like registry)
 - Log in SSH on the runner in order to debug the workflow
-In the first case, you can also configure Tailscale to automatically start SSH server in case of job failure
+In the first case, you can also configure Tailscale to automatically start an SSH server in case of job failure
 
-# Access to internal shared ressources (like registry)
+# Access to internal shared resources (like registry)
 
 Ask for the TAILSCALE_AUTHKEY secret and add this step to your workflow. 
 
@@ -17,8 +17,8 @@ Ask for the TAILSCALE_AUTHKEY secret and add this step to your workflow.
       authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 ```
 
-You can configure This Tailscale Action to run dynamically an SSH server on your runner if a step failed, or if you started your job with debug mode.
-In this case, you have to add 2 inputs for slack notification and add a "wait" step at the end of your job
+You can configure this Tailscale Action to run dynamically an SSH server on your runner if a step failed, or if you started your job with debug mode.
+In this case, you have to add 2 inputs for Slack notification and add a "wait" step at the end of your job
 
 ```yaml
   - name: Tailscale
@@ -41,7 +41,7 @@ In this case, you have to add 2 inputs for slack notification and add a "wait" s
 
 
 - Add this step at the end of your job (`TAILSCALE_SSH_AUTHKEY`, `SLACK_CIFEEDBACK_CHANNEL`, `SLACK_CIFEEDBACK_BOT_TOKEN` already available on all repos)
-- Re-Run your Job with `Enable debug logging` on the github popup
+- Re-Run your Job with `Enable debug logging` on the GitHub popup
 - Join the slack channel #github-runners, you will receive a slack message.
 
 ```yaml
@@ -77,6 +77,6 @@ Tooltip : If you want to connect to the runner at the start of your workflow, to
        waitForSSH: true
 ```
 
-## Others options
+## Other options
 
 - `sshTimeout` : by default Tailscale is waiting 5 minutes before terminating the job. You can increase this time.


### PR DESCRIPTION
Eight fixes in the README, mostly French-influenced spelling and capitalization:

- `Based from` → `Based on`
- `Github` → `GitHub`, `github action` → `GitHub Action`
- `differents` → `different`
- `ressources` → `resources` (×2)
- `This Tailscale` → `this Tailscale` (mid-sentence)
- `start SSH server` → `start an SSH server` (missing article)
- `Others options` → `Other options`
- `slack` → `Slack`, `github` → `GitHub` (proper nouns)